### PR TITLE
Homework 1 fix + extra OOP task

### DIFF
--- a/src/main/java/org/tbogdanov/epamhw/module1/task4/VectorMaxExample.java
+++ b/src/main/java/org/tbogdanov/epamhw/module1/task4/VectorMaxExample.java
@@ -21,12 +21,12 @@ public class VectorMaxExample {
         }
 
         int half = dim / 2;
-        int max = 0;
+        int max = vector[0] + vector[dim-1];
         int sum = 0;
         int j = 0;
+        System.out.printf("a[%d] + a[%d] = %d\n", 1, dim, max);
 
-
-        for (int i = 0; i < half; i++) {
+        for (int i = 1; i < half; i++) {
             j = dim - i - 1;
             sum = vector[i] + vector[j];
 
@@ -34,7 +34,7 @@ public class VectorMaxExample {
                 System.out.printf("a[%d] + a[%d] = %d\n", i + 1, j + 1, sum);
             }
 
-            if (i == 0 || sum > max) {
+            if (sum > max) {
                 max = sum;
             }
         }

--- a/src/main/java/org/tbogdanov/epamhw/module1/task7/Bagpipe.java
+++ b/src/main/java/org/tbogdanov/epamhw/module1/task7/Bagpipe.java
@@ -1,0 +1,56 @@
+package org.tbogdanov.epamhw.module1.task7;
+
+/**
+ * Created by Timur Bogdanov on 11.02.18.
+ */
+
+// Overriding example
+public class Bagpipe extends MusicalInstrument implements VolumeSetInstrument {
+
+    private static final String SINGLE_SOUND = "skirl";
+    private static final String LONG_SOUND_BEGIN = "sk";
+    private static final String LONG_SOUND_MID = "i";
+    private static final String LONG_SOUND_END = "rl";
+
+    private static final double VOLUME_CAPS_THRESOLD = 50.0;
+
+    private double volume;
+
+    Bagpipe() {
+        volume = MAX_VOLUME;
+    }
+
+    public String getSound() {
+        return affectSoundByVolume(SINGLE_SOUND);
+    }
+
+    @Override
+    public String getSound(int n) {
+        StringBuilder soundSB = new StringBuilder(LONG_SOUND_BEGIN);
+        for (int i = 0; i < n; i++) {
+            soundSB.append(LONG_SOUND_MID);
+        }
+        soundSB.append(LONG_SOUND_END);
+        return affectSoundByVolume(soundSB.toString());
+    }
+
+
+    @Override
+    public void setVolume(double vol) throws IllegalArgumentException {
+        if (vol < MIN_VOLUME || vol > MAX_VOLUME) {
+            throw new IllegalArgumentException(String.format("Wrong volume! Allowed volume range: %f-%f",
+                    MIN_VOLUME, MAX_VOLUME));
+        }
+        volume = vol;
+    }
+
+    @Override
+    public double getVolume() {
+        return volume;
+    }
+
+    @Override
+    public String affectSoundByVolume(String snd) {
+        return (volume >= VOLUME_CAPS_THRESOLD? snd.toUpperCase() : snd);
+    }
+}

--- a/src/main/java/org/tbogdanov/epamhw/module1/task7/FortePiano.java
+++ b/src/main/java/org/tbogdanov/epamhw/module1/task7/FortePiano.java
@@ -1,0 +1,39 @@
+package org.tbogdanov.epamhw.module1.task7;
+
+import java.security.InvalidParameterException;
+import java.util.Random;
+
+/**
+ * Created by Timur Bogdanov on 11.02.18.
+ */
+// Additional fields and methods example
+public class FortePiano extends MusicalInstrument {
+    private static final Random random = new Random();    // No need to generate random seed for each instance.
+    private static String[] PIANO_SOUNDS = { "c", "d", "e", "f", "g", "a", "h" }; // see GrandPiano
+    private static int MIN_OCTAVE = 1;
+    private static int MAX_OCTAVE = 4;
+
+    protected int octave;
+
+    FortePiano() {
+        octave = 1;
+    }
+
+    @Override
+    public String getSound() {
+        return PIANO_SOUNDS[random.nextInt(PIANO_SOUNDS.length)]+Integer.toString(octave);
+    }
+
+    public void setOctave(int octave) throws InvalidParameterException {
+        if (octave < MIN_OCTAVE || octave > MAX_OCTAVE) {
+            throw new IllegalArgumentException(String.format("Wrong octave! Allowed octaves: %d-%d",
+                    MIN_OCTAVE, MAX_OCTAVE));
+        }
+        this.octave = octave;
+    }
+
+    public int getOctave() {
+        return this.octave;
+    }
+
+}

--- a/src/main/java/org/tbogdanov/epamhw/module1/task7/GrandPiano.java
+++ b/src/main/java/org/tbogdanov/epamhw/module1/task7/GrandPiano.java
@@ -1,0 +1,39 @@
+package org.tbogdanov.epamhw.module1.task7;
+
+/**
+ * Created by Timur Bogdanov on 11.02.18.
+ */
+
+// Multiple inheritance with additional methods example
+public class GrandPiano extends FortePiano {
+    private static String[] PIANO_SOUNDS = { "C", "D", "E", "F", "G", "A", "H" };
+    private static int MIN_OCTAVE = 0;
+    private static int MAX_OCTAVE = 5;
+
+    private boolean pedal = false;
+
+    GrandPiano() {
+        this.octave = 2;
+    }
+
+
+
+    public String getSpecificSound(int note) {
+        if (note >= 0 || note < PIANO_SOUNDS.length) {
+            String sound = PIANO_SOUNDS[note]+Integer.toString(octave);
+            return (pedal ? sound.toLowerCase() : sound);
+        }
+        else {
+            return "";
+        }
+    }
+
+    public void setPedal(boolean pedal) {
+        this.pedal = pedal;
+    }
+
+    public boolean getPedal() {
+        return this.pedal;
+    }
+
+}

--- a/src/main/java/org/tbogdanov/epamhw/module1/task7/Main.java
+++ b/src/main/java/org/tbogdanov/epamhw/module1/task7/Main.java
@@ -1,0 +1,107 @@
+package org.tbogdanov.epamhw.module1.task7;
+
+import java.util.Random;
+
+/**
+ * Created by Timur Bogdanov on 11.02.18.
+ */
+public class Main {
+    private static final Random random = new Random();
+
+    public static void printSound(MusicalInstrument instrument) {
+        System.out.printf("%s goes %s!\n", instrument.getClass().getName(), instrument.getSound());
+    }
+
+    public static void printSound(MusicalInstrument instrument, int n) {
+        System.out.printf("%s goes %s!\n", instrument.getClass().getName(), instrument.getSound(n));
+    }
+
+    public static void main(String[] args) {
+        Bagpipe bagpipe = new Bagpipe();
+        FortePiano fortePiano = new FortePiano();
+        GrandPiano grandPiano = new GrandPiano();
+        MusicalInstrument[] orchestra = {bagpipe, fortePiano, grandPiano};
+
+        // Example 1: Polymorphism
+        for (MusicalInstrument instrument: orchestra) {
+            printSound(instrument, random.nextInt(5) + 2);
+        }
+        /* Result:
+           All instruments play in a single loop using their similar method.
+           We used GrandPiano.getSound(int n) which hasn't been overriden
+           from FortePiano, so we got the sounds from static FortePiano.PIANO_SOUNDS
+           array. In Example 3 we'll try another case: getting from PIANO_SOUNDS
+           using a unique method.
+         */
+
+        // Example 2: Setting volume levels for an instance of Bagpipe
+        try {
+            bagpipe.setVolume(25.0);
+            System.out.println(bagpipe.getSound());
+            bagpipe.setVolume(75.0);
+            System.out.println(bagpipe.getSound());
+        } catch (IllegalArgumentException ex) {
+            System.out.println(ex.getMessage());
+        }
+        /* Result: works as intended.
+           volume 25.0: skirl
+           volume 75.0: SKIRL
+         */
+
+        // Example 3: GrandPiano.getSpecificSound()
+        System.out.println(grandPiano.getSpecificSound(2));
+        /* Result:
+           Unique methods, like the overridden ones, use GrandPiano.PIANO_SOUNDS,
+           as opposed to those who haven't been overridden, that use FortePiano.PIANO_SOUNDS.
+           Examples 1 and 3 demonstrate hiding of static fields.
+         */
+
+        // Example 4: Setting an octave supported by GrandPiano, but unsupported by FortePiano
+        try {
+            grandPiano.setOctave(5);
+            System.out.println(grandPiano.getSound());
+        } catch (IllegalArgumentException ex) {
+            System.out.println(ex.getMessage());
+        }
+        /* Result:
+           We haven't overridden GrandPiano.getSound(), so GrandPiano
+           uses the octave range from its ancestor, FortePiano.
+           The exception will be thrown.
+         */
+
+        // Example 5: GrandPiano as FortePiano
+        try {
+            System.out.println(((FortePiano) grandPiano).getSound());
+            //((FortePiano) grandPiano).getSpecificSound(1);
+        } catch (Exception ex) {
+            System.out.println(ex.getMessage());
+        }
+        /* Result:
+           ((FortePiano) grandPiano).getSpecificSound(1) won't work for an obvious reason:
+           FortePiano doesn't have this method.
+           getSound() will use FortePiano.PIANO_SOUNDS.
+         */
+
+        // Example 6: FortePiano as GrandPiano
+        try {
+            printSound((GrandPiano) fortePiano);
+            ((GrandPiano) fortePiano).getSpecificSound(1);
+        } catch (Exception ex) {
+            System.out.println(ex.getMessage());
+        }
+        /* Result:
+           This casting is illegal. Any of those 2 lines will throw an exception.
+         */
+
+
+
+
+
+    }
+
+
+
+
+
+
+}

--- a/src/main/java/org/tbogdanov/epamhw/module1/task7/MusicalInstrument.java
+++ b/src/main/java/org/tbogdanov/epamhw/module1/task7/MusicalInstrument.java
@@ -1,0 +1,23 @@
+package org.tbogdanov.epamhw.module1.task7;
+
+/**
+ * Created by Timur Bogdanov on 11.02.18.
+ */
+
+/* Inheritance hierarchy:
+   Bagpipe -> MusicalInstrument
+   GrandPiano -> FortePiano -> MusicalInstrument
+ */
+public abstract class MusicalInstrument {
+
+    public abstract String getSound();
+
+    public String getSound(int n) {
+        String sound = new String();
+        for (int i = 0; i < n; i++) {
+            sound = sound.concat(getSound() + " ");
+        }
+        return sound;
+    }
+
+}

--- a/src/main/java/org/tbogdanov/epamhw/module1/task7/VolumeSetInstrument.java
+++ b/src/main/java/org/tbogdanov/epamhw/module1/task7/VolumeSetInstrument.java
@@ -1,0 +1,24 @@
+package org.tbogdanov.epamhw.module1.task7;
+
+/**
+ * Created by Timur Bogdanov on 08.04.18.
+ */
+public interface VolumeSetInstrument {
+    /* Assume that we have volume sliders on our instruments.
+       Instruments can handle volume in different ways:
+       for example the string representation of a sound may
+       turn caps ("ding" -> "DING") when the volume
+       reaches a specific thresold. It should be specified in
+       the affectSoundByVolume() method.
+     */
+
+    final double MIN_VOLUME = 0.0;
+    final double MAX_VOLUME = 100.0;
+    /* You can't really define a non-final non-static field for current module.
+     */
+
+    void setVolume(double vol);
+    double getVolume();
+    String affectSoundByVolume(String snd);
+
+}


### PR DESCRIPTION
- Исправления к задаче 4. Первая итерация, определяющая изначальный максимум, вынесена из цикла.
- Дополнительное задание (ООП)

# Пояснения к доп. заданию
## Структура классов
MusicalInstrument ← FortePiano ← GrandPiano
MusicalInstrument ← Bagpipe (использует интерфейс VolumeInstrument)
## FortePiano и GrandPiano
Здесь я попытался поковыряться с такой вещью, как скрытие статических полей. Для этого в класс FortePiano были намеренно добавлены поля с заданными значениями:
```
private static String[] PIANO_SOUNDS = { "c", "d", "e", "f", "g", "a", "h" };
private static int MIN_OCTAVE = 1;
private static int MAX_OCTAVE = 4;
```
Те же поля, но с другими значениями были добавлены в класс-наследник GrandPiano.
По итогам работы программы выяснилось, что те методы, что были просто унаследованы GrandPiano от FortePiano, использовали стат. поля от FortePiano, в то время как явно описанные в GrandPiano методы использовали стат. поля GrandPiano. См. пояснения к примерам в Main.java.
## Bagpipe
("волынка") Этот пример демонстрирует работу с интерфейсом VolumeInstrument. Сам интерфейс плохо подходит для обозначения не-константных полей (в нём поля становятся static final), поэтому поле, связанное с текущей громкостью (private int volume) пришлось описывать уже внутри Bagpipe. Возможно, тут лучше бы подошло использование VolumeInstrument не как интерфейса, а как родительского класса.